### PR TITLE
fix(rncp-simulator): preserve manual projects XP after page refresh

### DIFF
--- a/app/(main)/rncp-simulator/page.tsx
+++ b/app/(main)/rncp-simulator/page.tsx
@@ -165,6 +165,28 @@ export default function RNCPSimulator() {
     [manualProjectsKey],
   )
 
+  const { setProjectMark, toggleCoalitionBonus, coalitionProjects } = useFortyTwoStore(
+    (state) => ({
+      setProjectMark: state.setProjectMark,
+      toggleCoalitionBonus: state.toggleCoalitionBonus,
+      coalitionProjects: state.coalitionProjects,
+    }),
+    shallow,
+  )
+
+  const hasRestoredManualProjects = useRef(false)
+  useEffect(() => {
+    if (isDataProcessed && manualProjects.length > 0 && !hasRestoredManualProjects.current) {
+      hasRestoredManualProjects.current = true
+      manualProjects.forEach((project) => {
+        setProjectMark(project.id, project.mark, true)
+        if (project.coa && !coalitionProjects.has(project.id)) {
+          toggleCoalitionBonus(project.id)
+        }
+      })
+    }
+  }, [isDataProcessed, manualProjects, setProjectMark, toggleCoalitionBonus, coalitionProjects])
+
   const isLoading = !hydrated || isIntraLoading || areEventsLoading || !isDataProcessed
 
   if (isLoading) {

--- a/types/forty-two.ts
+++ b/types/forty-two.ts
@@ -11,11 +11,10 @@ export interface FortyTwoProject {
   exam: boolean
   parent: { name: string; id: number; slug: string } | null
   children: { name: string; id: number; slug: string }[]
-  // User-specific fields
   mark?: number
   bonus?: boolean
   validated?: boolean
-  is_solo?: boolean // Added for group project detection
+  is_solo?: boolean
 }
 export interface FortyTwoCursus {
   id: number
@@ -73,7 +72,7 @@ export interface FortyTwoStore {
   projects: Record<number, FortyTwoProject>;
   titles: FortyTwoTitle[];
   projectMarks: Map<number, number>;
-  setProjectMark: (projectId: number, mark: number) => void;
+  setProjectMark: (projectId: number, mark: number, onlySelf?: boolean) => void;
   removeProject: (projectId: number) => void;
   getSelectedXP: () => number;
   getProjectXP: (project: FortyTwoProject) => number;
@@ -84,7 +83,6 @@ export interface FortyTwoStore {
   isProjectModuleComplete: (project: FortyTwoProject) => boolean;
   getExperienceForOption: (option: FortyTwoTitleOption) => number;
   getLevel: (experience: number) => number;
-  // Added for requirements UI
   professionalExperiences: Set<string>;
   toggleProfessionalExperience: (experience: string) => void;
   setProfessionalExperienceMark: (experience: string, mark: number) => void;


### PR DESCRIPTION
- Save all necessary state fields (initialXPDelta, autoFetchedProjectMarks, professionalExperienceMarks) to localStorage
- Calculate initialXPDelta only from auto-fetched projects to avoid XP loss
- Preserve manual projects when processInitialData runs
- Restore full state during store hydration
- Fix TypeScript type for setProjectMark to include onlySelf parameter

Fixes issue where manually selected projects would remain checked after refresh but lose their XP contribution